### PR TITLE
feat: add native bridge to read cie data (Android only)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,51 +101,52 @@ jobs:
         run: |
           yarn turbo run build:android --cache-dir="${{ env.TURBO_CACHE_DIR }}"
 
-  build-ios:
-    runs-on: macos-latest
-    env:
-      TURBO_CACHE_DIR: .turbo/ios
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+  # Remove this line because we don't have an iOS example yet
+  #build-ios:
+  #  runs-on: macos-latest
+  #  env:
+  #    TURBO_CACHE_DIR: .turbo/ios
+  #  steps:
+  #    - name: Checkout
+  #      uses: actions/checkout@v3
 
-      - name: Setup
-        uses: ./.github/actions/setup
+  #    - name: Setup
+  #      uses: ./.github/actions/setup
 
-      - name: Cache turborepo for iOS
-        uses: actions/cache@v3
-        with:
-          path: ${{ env.TURBO_CACHE_DIR }}
-          key: ${{ runner.os }}-turborepo-ios-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-turborepo-ios-
+  #    - name: Cache turborepo for iOS
+  #      uses: actions/cache@v3
+  #      with:
+  #        path: ${{ env.TURBO_CACHE_DIR }}
+  #        key: ${{ runner.os }}-turborepo-ios-${{ hashFiles('**/yarn.lock') }}
+  #        restore-keys: |
+  #          ${{ runner.os }}-turborepo-ios-
 
-      - name: Check turborepo cache for iOS
-        run: |
-          TURBO_CACHE_STATUS=$(node -p "($(yarn --silent turbo run build:ios --cache-dir="${{ env.TURBO_CACHE_DIR }}" --dry=json)).tasks.find(t => t.task === 'build:ios').cache.status")
+  #    - name: Check turborepo cache for iOS
+  #      run: |
+  #        TURBO_CACHE_STATUS=$(node -p "($(yarn --silent turbo run build:ios --cache-dir="${{ env.TURBO_CACHE_DIR }}" --dry=json)).tasks.find(t => t.task === 'build:ios').cache.status")
 
-          if [[ $TURBO_CACHE_STATUS == "HIT" ]]; then
-            echo "turbo_cache_hit=1" >> $GITHUB_ENV
-          fi
+  #        if [[ $TURBO_CACHE_STATUS == "HIT" ]]; then
+  #          echo "turbo_cache_hit=1" >> $GITHUB_ENV
+  #        fi
 
-      - name: Cache cocoapods
-        if: env.turbo_cache_hit != 1
-        id: cocoapods-cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            **/ios/Pods
-          key: ${{ runner.os }}-cocoapods-${{ hashFiles('example/ios/Podfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cocoapods-
+  #    - name: Cache cocoapods
+  #      if: env.turbo_cache_hit != 1
+  #      id: cocoapods-cache
+  #      uses: actions/cache@v3
+  #      with:
+  #        path: |
+  #          **/ios/Pods
+  #        key: ${{ runner.os }}-cocoapods-${{ hashFiles('example/ios/Podfile.lock') }}
+  #        restore-keys: |
+  #          ${{ runner.os }}-cocoapods-
 
-      - name: Install cocoapods
-        if: env.turbo_cache_hit != 1 && steps.cocoapods-cache.outputs.cache-hit != 'true'
-        run: |
-          yarn example pods
-        env:
-          NO_FLIPPER: 1
+  #    - name: Install cocoapods
+  #      if: env.turbo_cache_hit != 1 && steps.cocoapods-cache.outputs.cache-hit != 'true'
+  #      run: |
+  #        yarn example pods
+  #      env:
+  #        NO_FLIPPER: 1
 
-      - name: Build example for iOS
-        run: |
-          yarn turbo run build:ios --cache-dir="${{ env.TURBO_CACHE_DIR }}"
+  #    - name: Build example for iOS
+  #      run: |
+  #        yarn turbo run build:ios --cache-dir="${{ env.TURBO_CACHE_DIR }}"

--- a/android/src/main/java/com/ioreactnativeciepid/IoReactNativeCiePidModule.kt
+++ b/android/src/main/java/com/ioreactnativeciepid/IoReactNativeCiePidModule.kt
@@ -1,25 +1,197 @@
 package com.ioreactnativeciepid
 
+import com.facebook.react.bridge.Arguments.createMap
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.WritableMap
+import com.facebook.react.modules.core.RCTNativeAppEventEmitter
+import it.ipzs.androidpidprovider.external.PidProviderConfig
+import it.ipzs.androidpidprovider.external.PidProviderSdk
+import it.ipzs.cieidsdk.common.Callback
+import it.ipzs.cieidsdk.common.CieIDSdk
+import it.ipzs.cieidsdk.event.Event
+import android.content.Intent
+import android.app.Activity
+import android.net.Uri
+import it.ipzs.cieidsdk.data.PidCieData
 
 class IoReactNativeCiePidModule(reactContext: ReactApplicationContext) :
-  ReactContextBaseJavaModule(reactContext) {
+  ReactContextBaseJavaModule(reactContext), Callback {
+
+  private var ciePinAttemptsLeft: Int = 0
 
   override fun getName(): String {
     return NAME
   }
 
-  // Example method
-  // See https://reactnative.dev/docs/native-modules-android
+  /**
+   * onSuccess is called when the CIE authentication is successfully completed.
+   * @param[url] the form consent url
+   */
+  override fun onSuccess(url: String, pinCieData: PidCieData?) {
+    this.sendEvent(successChannel, url)
+  }
+
+  /**
+   * onError is called if some errors occurred during CIE authentication
+   * @param[error] the error occurred
+   */
+  override fun onError(error: Throwable) {
+    this.sendEvent(errorChannel, error.message ?: "generic error")
+  }
+
+  /**
+   * onEvent is called if an event occurs
+   */
+  override fun onEvent(event: Event) {
+    ciePinAttemptsLeft = event.attempts ?: ciePinAttemptsLeft
+    this.sendEvent(eventChannel,event.event.toString())
+  }
+
+  private fun getWritableMap(eventValue: String): WritableMap {
+    val writableMap = createMap()
+    writableMap.putString("event", eventValue)
+    writableMap.putInt("attemptsLeft", ciePinAttemptsLeft)
+    return writableMap
+  }
+
+  private fun sendEvent(channel: String, eventValue: String) {
+    reactApplicationContext
+      .getJSModule(RCTNativeAppEventEmitter::class.java)
+      .emit(channel, getWritableMap(eventValue))
+  }
+
+
   @ReactMethod
-  fun multiply(a: Double, b: Double, promise: Promise) {
-    promise.resolve(a * b)
+  fun start(callback: com.facebook.react.bridge.Callback) {
+    try {
+      CieIDSdk.start(getCurrentActivity()!!, this)
+      callback.invoke()
+    } catch (e: RuntimeException) {
+      callback.invoke(e.message)
+    }
+  }
+
+  @ReactMethod
+  fun isNFCEnabled(callback: com.facebook.react.bridge.Callback) {
+
+    callback.invoke(CieIDSdk.isNFCEnabled(reactApplicationContext))
+  }
+
+  @ReactMethod
+  fun hasNFCFeature(callback: com.facebook.react.bridge.Callback) {
+    callback.invoke(CieIDSdk.hasFeatureNFC(reactApplicationContext))
+  }
+
+  @ReactMethod
+  fun setPin(pin: String, callback: com.facebook.react.bridge.Callback) {
+    try {
+      CieIDSdk.pin = pin
+      callback.invoke()
+    } catch (e: IllegalArgumentException) {
+      callback.invoke(e.message)
+    }
+  }
+
+  @ReactMethod
+  fun setAuthenticationUrl(url: String) {
+    CieIDSdk.setUrl(url)
+  }
+
+  @ReactMethod
+  fun startListeningNFC(callback: com.facebook.react.bridge.Callback) {
+    try {
+      CieIDSdk.startNFCListening(getCurrentActivity()!!)
+      callback.invoke()
+    } catch (e: RuntimeException) {
+      callback.invoke(e.message)
+    }
+  }
+
+  @ReactMethod
+  fun stopListeningNFC(callback: com.facebook.react.bridge.Callback) {
+    try {
+      CieIDSdk.stopNFCListening(getCurrentActivity()!!)
+      callback.invoke()
+    } catch (e: RuntimeException) {
+      callback.invoke(e.message)
+    }
   }
 
   companion object {
+    const val eventChannel: String = "onEvent"
+    const val errorChannel: String = "onError"
+    const val successChannel: String = "onSuccess"
     const val NAME = "IoReactNativeCiePid"
   }
+
+  @ReactMethod
+  fun openNFCSettings(callback: com.facebook.react.bridge.Callback) {
+    val currentActivity = getCurrentActivity()!!
+    if (currentActivity == null) {
+      callback.invoke("fail to get current activity");
+    } else {
+      CieIDSdk.openNFCSettings(currentActivity)
+      callback.invoke()
+    }
+  }
+
+  @ReactMethod
+  fun hasApiLevelSupport(callback: com.facebook.react.bridge.Callback) {
+    callback.invoke(CieIDSdk.hasApiLevelSupport())
+  }
+
+  @ReactMethod
+  fun launchCieID(callback: com.facebook.react.bridge.Callback) {
+    val currentActivity = getCurrentActivity()!!
+    if (currentActivity == null) {
+      callback.invoke("fail to get current activity")
+    } else {
+      this.launchCieID(currentActivity)
+      callback.invoke()
+    }
+  }
+
+  /**
+   * Open CieID application
+   * Use this method when receive CieIDEvent.Card.ON_CARD_PIN_LOCKED. User needs to unlock CIE after 3 pin error.
+   */
+  fun launchCieID(activity: Activity){
+    val cieIdPackage = "it.ipzs.cieid"
+    val launchIntent = activity.getPackageManager().getLaunchIntentForPackage(cieIdPackage);
+    if(launchIntent == null){
+      activity.startActivity(Intent(Intent.ACTION_VIEW).setData(Uri.parse("https://play.google.com/store/apps/details?id=$cieIdPackage")))
+    }
+    else{
+      activity.startActivity(launchIntent)
+    }
+  }
+
+  @ReactMethod
+  fun initializeSDK(promise: Promise) {
+    try {
+      val walletInstance =
+        "eyJhbGciOiJFUzI1NiIsImtpZCI6IjV0NVlZcEJoTi1FZ0lFRUk1aVV6cjZyME1SMDJMblZRME9tZWttTktjalkiLCJ0cnVzdF9jaGFpbiI6WyJleUpoYkdjaU9pSkZVei4uLjZTMEEiLCJleUpoYkdjaU9pSkZVei4uLmpKTEEiLCJleUpoYkdjaU9pSkZVei4uLkg5Z3ciXSwidHlwIjoidmErand0IiwieDVjIjpbIk1JSUJqRENDIC4uLiBYRmVoZ0tRQT09Il19.eyJpc3MiOiJodHRwczovL3dhbGxldC1wcm92aWRlci5leGFtcGxlLm9yZyIsInN1YiI6InZiZVhKa3NNNDV4cGh0QU5uQ2lHNm1DeXVVNGpmR056b3BHdUt2b2dnOWMiLCJ0eXBlIjoiV2FsbGV0SW5zdGFuY2VBdHRlc3RhdGlvbiIsInBvbGljeV91cmkiOiJodHRwczovL3dhbGxldC1wcm92aWRlci5leGFtcGxlLm9yZy9wcml2YWN5X3BvbGljeSIsInRvc191cmkiOiJodHRwczovL3dhbGxldC1wcm92aWRlci5leGFtcGxlLm9yZy9pbmZvX3BvbGljeSIsImxvZ29fdXJpIjoiaHR0cHM6Ly93YWxsZXQtcHJvdmlkZXIuZXhhbXBsZS5vcmcvbG9nby5zdmciLCJhc2MiOiJodHRwczovL3dhbGxldC1wcm92aWRlci5leGFtcGxlLm9yZy9Mb0EvYmFzaWMiLCJjbmYiOnsiandrIjp7ImNydiI6IlAtMjU2Iiwia3R5IjoiRUMiLCJ4IjoiNEhOcHRJLXhyMnBqeVJKS0dNbno0V21kblFEX3VKU3E0Ujk1Tmo5OGI0NCIsInkiOiJMSVpuU0IzOXZGSmhZZ1MzazdqWEU0cjMtQ29HRlF3WnRQQklScXBObHJnIiwia2lkIjoidmJlWEprc000NXhwaHRBTm5DaUc2bUN5dVU0amZHTnpvcEd1S3ZvZ2c5YyJ9fSwiYXV0aG9yaXphdGlvbl9lbmRwb2ludCI6ImV1ZGl3OiIsInJlc3BvbnNlX3R5cGVzX3N1cHBvcnRlZCI6WyJ2cF90b2tlbiJdLCJ2cF9mb3JtYXRzX3N1cHBvcnRlZCI6eyJqd3RfdnBfanNvbiI6eyJhbGdfdmFsdWVzX3N1cHBvcnRlZCI6WyJFUzI1NiJdfSwiand0X3ZjX2pzb24iOnsiYWxnX3ZhbHVlc19zdXBwb3J0ZWQiOlsiRVMyNTYiXX19LCJyZXF1ZXN0X29iamVjdF9zaWduaW5nX2FsZ192YWx1ZXNfc3VwcG9ydGVkIjpbIkVTMjU2Il0sInByZXNlbnRhdGlvbl9kZWZpbml0aW9uX3VyaV9zdXBwb3J0ZWQiOmZhbHNlLCJpYXQiOjE2ODcyODExOTUsImV4cCI6MTY4NzI4ODM5NX0.OTuPik6p3o9j6VOx-uCyxRvHwoh1pDiiZcBQFNQt2uE3dK-8izGNflJVETi_uhGSZOf25Enkq-UvEin9NrbJNw"
+
+      val pidProviderConfig = PidProviderConfig
+        .Builder()
+        .baseUrl("https://api.wakala.it/it-pid-provider/") // TODO: Update base url
+        .walletInstance(walletInstance)
+        .walletUri("https://www.google.com")
+        .logEnabled(true)
+        .build()
+
+      PidProviderSdk.initialize(
+        reactApplicationContext,
+        pidProviderConfig = pidProviderConfig
+      )
+      promise.resolve("Initialization completed")
+    } catch(e: Error) {
+      promise.reject("Problem occurs during initialization")
+    }
+
+  }
+
 }

--- a/android/src/main/java/com/ioreactnativeciepid/IoReactNativeCiePidModule.kt
+++ b/android/src/main/java/com/ioreactnativeciepid/IoReactNativeCiePidModule.kt
@@ -16,6 +16,7 @@ import android.content.Intent
 import android.app.Activity
 import android.net.Uri
 import it.ipzs.cieidsdk.data.PidCieData
+import org.json.JSONObject
 
 class IoReactNativeCiePidModule(reactContext: ReactApplicationContext) :
   ReactContextBaseJavaModule(reactContext), Callback {
@@ -31,7 +32,11 @@ class IoReactNativeCiePidModule(reactContext: ReactApplicationContext) :
    * @param[url] the form consent url
    */
   override fun onSuccess(url: String, pinCieData: PidCieData?) {
-    this.sendEvent(successChannel, url)
+    val cieDataString = pinCieData?.toString() ?: ""
+    val eventData = JSONObject()
+    eventData.put("url", url)
+    eventData.put("cieData", cieDataString)
+    this.sendEvent(successChannel, eventData.toString())
   }
 
   /**

--- a/android/src/main/java/it/ipzs/androidpidprovider/facade/PidProviderFacade.kt
+++ b/android/src/main/java/it/ipzs/androidpidprovider/facade/PidProviderFacade.kt
@@ -34,7 +34,8 @@ internal class PidProviderFacade(
             val requestUri = pkceFacade.requestPar(signedJwtForPar)
             pkceFacade.loadAuthorizeWebview(activity, requestUri,cdAuthorize)
             val authorizeResponse = cdAuthorize.await().orEmpty()
-            val proof = pkceFacade.getToken(authorizeResponse, requestUri)
+            val redirectUri = sharedPreferences.getWalletUri()
+            val proof = pkceFacade.getToken(authorizeResponse, redirectUri)
             sharedPreferences.saveUnsignedJWTProof(proof)
             PidSdkStartCallbackManager.invokeOnComplete(true)
         }

--- a/android/src/main/java/it/ipzs/cieidsdk/common/CieIDSdk.kt
+++ b/android/src/main/java/it/ipzs/cieidsdk/common/CieIDSdk.kt
@@ -39,6 +39,7 @@ import it.ipzs.cieidsdk.nfc.algorithms.Sha256
 import it.ipzs.cieidsdk.nfc.extensions.toHex
 import it.ipzs.cieidsdk.url.DeepLinkInfo
 import it.ipzs.cieidsdk.util.CieIDSdkLogger
+import it.ipzs.cieidsdk.util.FiscalCodeUtil.extractBirthDateFromFiscalCode
 import okhttp3.CertificatePinner
 import okhttp3.ResponseBody
 import retrofit2.Response
@@ -196,15 +197,13 @@ object CieIDSdk : NfcAdapter.ReaderCallback {
         val dn = userCertificateHolder?.subject
         val dnGivenName = getValueFromRdns(dn, BCStyle.GIVENNAME)
         val dnSurname = getValueFromRdns(dn, BCStyle.SURNAME)
-        val dnDateOfBirth = getValueFromRdns(dn, BCStyle.DATE_OF_BIRTH)
-        val dnFiscalCode = getValueFromRdns(dn, BCStyle.UNIQUE_IDENTIFIER)
+        val dnFiscalCode = getValueFromRdns(dn, BCStyle.CN)
         val name = rdnToString(dnGivenName)
         val surname = rdnToString(dnSurname)
-        val dateOfBirth = rdnToString(dnDateOfBirth)
-        val fiscalCode = rdnToString(dnFiscalCode)
+        val fiscalCode = rdnToString(dnFiscalCode)?.split("/")?.firstOrNull().toString()
+        val dateOfBirth = extractBirthDateFromFiscalCode(fiscalCode)
         return PidCieData(name, surname, fiscalCode, dateOfBirth)
     }
-
 
     private fun checkCodiceServer(codiceServer: String): Boolean {
         val regex = Regex("^[0-9]{16}$")

--- a/android/src/main/java/it/ipzs/cieidsdk/common/CieIDSdk.kt
+++ b/android/src/main/java/it/ipzs/cieidsdk/common/CieIDSdk.kt
@@ -90,7 +90,7 @@ object CieIDSdk : NfcAdapter.ReaderCallback {
 
     fun createCertificatePinning(){
         certificatePinner = CertificatePinner.Builder()
-            .add(BuildConfig.BASE_URL_CERTIFICATE, BuildConfig.PIN_ROOT)
+            .add(BuildConfig.BASE_URL_CERTIFICATE,BuildConfig.PIN_ROOT)
             .add(BuildConfig.BASE_URL_CERTIFICATE,BuildConfig.PIN_LEAF)
             .build()
     }

--- a/android/src/main/java/it/ipzs/cieidsdk/nfc/Ias.kt
+++ b/android/src/main/java/it/ipzs/cieidsdk/nfc/Ias.kt
@@ -896,8 +896,8 @@ internal class Ias constructor(val isoDep: IsoDep) {
             0x80.toByte())
         val response = sendApdu(getKeyDoup, getKeyDuopData, null)
         val asn1 = Asn1Tag.parse(response.response, true)
-        caModule = asn1!!.child(0).child(0).Child(0, 0x81.toByte()).data
-        caPubExp = asn1.child(0).child(0).Child(1, 0x82.toByte()).data
+        caModule = asn1!!.child(0).child(0).childWithTagID(byteArrayOf(0x81.toByte()))!!.data
+        caPubExp = asn1.child(0).child(0).childWithTagID(byteArrayOf(0x82.toByte()))!!.data
         baExtAuth_PrivExp = byteArrayOf(
             0x18,
             0x6B,

--- a/android/src/main/java/it/ipzs/cieidsdk/util/FiscalCodeUtil.kt
+++ b/android/src/main/java/it/ipzs/cieidsdk/util/FiscalCodeUtil.kt
@@ -1,0 +1,54 @@
+package it.ipzs.cieidsdk.util
+
+import java.util.*
+
+internal object FiscalCodeUtil {
+
+    fun extractBirthDateFromFiscalCode(fiscalCode: String): String? {
+        if (fiscalCode.length != 16) {
+            return null
+        }
+
+        val lastTwoDigitYear = fiscalCode.substring(6, 8).toInt()
+        val fullYear = getFullYear(lastTwoDigitYear)
+
+        val monthLetter = fiscalCode.substring(8, 9)
+        val month = getMonthFromLetter(monthLetter)
+
+        var day = fiscalCode.substring(9, 11).toInt()
+        if (day > 31) {
+            day -= 40
+        }
+
+        return "$fullYear-$month-$day"
+    }
+
+    private fun getMonthFromLetter(monthLetter: String): String {
+        return when (monthLetter) {
+            "A" -> "01"
+            "B" -> "02"
+            "C" -> "03"
+            "D" -> "04"
+            "E" -> "05"
+            "H" -> "06"
+            "L" -> "07"
+            "M" -> "08"
+            "P" -> "09"
+            "R" -> "10"
+            "S" -> "11"
+            "T" -> "12"
+            else -> "01"
+        }
+    }
+
+    private fun getFullYear(year: Int): Int {
+        val currentYear = Calendar.getInstance().get(Calendar.YEAR)
+        val century = (currentYear/100) * 100
+        val lastTwoDigits = currentYear - century
+        return if (year > lastTwoDigits) {
+            (century - 100) + year
+        } else {
+            century + year
+        }
+    }
+}

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -21,10 +21,10 @@ export default function App() {
   const [ciePin, onChangeCiePin] = React.useState('');
   const [info, setInfo] = React.useState('');
 
-  const cieAuthorizationUri =
-    'https://idserver.servizicie.interno.gov.it/idp/protocol/openid-connect/auth';
+  // const cieAuthorizationUri = 'http://localhost';
 
   React.useEffect(() => {
+    console.log('=== STARTING CIE MANAGER ===');
     CieManager.start()
       .then(async () => {
         CieManager.onEvent(handleCieEvent);
@@ -38,21 +38,25 @@ export default function App() {
   }, []);
 
   const handleCieEvent = async (event: any) => {
+    console.log('=== EVENT ===');
     console.log(event);
   };
 
   const handleCieError = async (event: any) => {
+    console.log('=== ERROR ===');
     console.log(event);
   };
 
   const handleCieSuccess = async (event: any) => {
+    console.log('=== SUCCESS ===');
     console.log(event);
   };
 
   const handleCieAuthentication = async () => {
     try {
+      console.log(ciePin);
       await CieManager.setPin(ciePin);
-      CieManager.setAuthenticationUrl(cieAuthorizationUri);
+      // CieManager.setAuthenticationUrl(cieAuthorizationUri);
       await CieManager.startListeningNFC();
     } catch (error) {
       console.error(error);

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,31 +1,75 @@
 import * as React from 'react';
-
-import { StyleSheet, View, Text } from 'react-native';
-import { multiply } from 'io-react-native-cie-pid';
-
-export default function App() {
-  const [result, setResult] = React.useState<number | undefined>();
-
-  React.useEffect(() => {
-    multiply(3, 7).then(setResult);
-  }, []);
-
-  return (
-    <View style={styles.container}>
-      <Text>Result: {result}</Text>
-    </View>
-  );
-}
+import CieManager from 'io-react-native-cie-pid';
+import {
+  Button,
+  SafeAreaView,
+  StyleSheet,
+  Text,
+  TextInput,
+} from 'react-native';
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  box: {
-    width: 60,
-    height: 60,
-    marginVertical: 20,
+  input: {
+    height: 40,
+    margin: 12,
+    borderWidth: 1,
+    padding: 10,
   },
 });
+
+export default function App() {
+  const [ciePin, onChangeCiePin] = React.useState('');
+  const [info, setInfo] = React.useState('');
+
+  const cieAuthorizationUri =
+    'https://idserver.servizicie.interno.gov.it/idp/protocol/openid-connect/auth';
+
+  React.useEffect(() => {
+    CieManager.start()
+      .then(async () => {
+        CieManager.onEvent(handleCieEvent);
+        CieManager.onError(handleCieError);
+        CieManager.onSuccess(handleCieSuccess);
+        setInfo('CieManager started');
+      })
+      .catch(() => {
+        setInfo('CieManager not started');
+      });
+  }, []);
+
+  const handleCieEvent = async (event: any) => {
+    console.log(event);
+  };
+
+  const handleCieError = async (event: any) => {
+    console.log(event);
+  };
+
+  const handleCieSuccess = async (event: any) => {
+    console.log(event);
+  };
+
+  const handleCieAuthentication = async () => {
+    try {
+      await CieManager.setPin(ciePin);
+      CieManager.setAuthenticationUrl(cieAuthorizationUri);
+      await CieManager.startListeningNFC();
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  return (
+    <SafeAreaView>
+      <TextInput
+        style={styles.input}
+        onChangeText={onChangeCiePin}
+        value={ciePin}
+        placeholder="insert cie pin"
+        keyboardType="numeric"
+      />
+      <Button title="continue" onPress={handleCieAuthentication} />
+      <Text>{info}</Text>
+    </SafeAreaView>
+  );
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,4 @@
-import { NativeModules, Platform } from 'react-native';
+import { NativeEventEmitter, NativeModules, Platform } from 'react-native';
 
 const LINKING_ERROR =
   `The package 'io-react-native-cie-pid' doesn't seem to be linked. Make sure: \n\n` +
@@ -17,6 +17,272 @@ const IoReactNativeCiePid = NativeModules.IoReactNativeCiePid
       }
     );
 
-export function multiply(a: number, b: number): Promise<number> {
-  return IoReactNativeCiePid.multiply(a, b);
-}
+const isIosDeviceCompatible =
+  IoReactNativeCiePid !== null &&
+  Platform.OS === 'ios' &&
+  parseInt(Platform.Version, 10) >= 13;
+
+// On Android, the events are sent by sending an intent from the native code to
+// the JS code. The JS code registers a broadcast receiver that will receive
+// the intent and emit the event.
+//
+// On iOS, the events are sent by sending a notification from the native code to
+// the JS code. The JS code registers a listener for the notification and emits
+// the event.
+//
+
+type EventHandler = (event: any) => void;
+
+const CieManager = () => {
+  const _eventSuccessHandlers: EventHandler[] = [];
+  const _eventErrorHandlers: EventHandler[] = [];
+  const _eventHandlers: EventHandler[] = [];
+
+  /**
+   * private
+   */
+  const _registerEventEmitter = () => {
+    if (Platform.OS === 'ios' && !isIosDeviceCompatible) {
+      return;
+    }
+    const NativeCieEmitter = new NativeEventEmitter(IoReactNativeCiePid);
+    NativeCieEmitter.addListener('onEvent', (e) => {
+      _eventHandlers.forEach((h) => h(e));
+    });
+    NativeCieEmitter.addListener('onSuccess', (e) => {
+      _eventSuccessHandlers.forEach((h) => h(e.event));
+    });
+    NativeCieEmitter.addListener('onError', (e) => {
+      _eventErrorHandlers.forEach((h) => h(new Error(e.event)));
+    });
+  };
+
+  _registerEventEmitter();
+
+  const onEvent = (listener: any) => {
+    if (!_eventHandlers.includes(listener)) {
+      _eventHandlers.push(listener);
+    }
+  };
+
+  const onError = (listener: any) => {
+    if (!_eventErrorHandlers.includes(listener)) {
+      _eventErrorHandlers.push(listener);
+    }
+  };
+
+  const onSuccess = (listener: any) => {
+    if (!_eventSuccessHandlers.includes(listener)) {
+      _eventSuccessHandlers.push(listener);
+    }
+  };
+
+  const removeAllListeners = () => {
+    _eventSuccessHandlers.length = 0;
+    _eventErrorHandlers.length = 0;
+    _eventHandlers.length = 0;
+  };
+
+  /**
+   * set the CIE pin. If the format doesn't respect a 8 length string of digits
+   * the promise will be rejected
+   */
+  const setPin = (pin: string) => {
+    if (Platform.OS === 'ios') {
+      return new Promise<void>((resolve, reject) => {
+        if (!isIosDeviceCompatible) {
+          reject('this device is not compatible');
+          return;
+        }
+        IoReactNativeCiePid.setPin(pin);
+        resolve();
+      });
+    }
+    return new Promise<void>((resolve, reject) => {
+      IoReactNativeCiePid.setPin(pin, (err: any) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
+  };
+
+  const setAlertMessage = (key: any, value: any) => {
+    if (isIosDeviceCompatible) {
+      IoReactNativeCiePid.setAlertMessage(key, value);
+    }
+  };
+
+  const setAuthenticationUrl = (url: string) => {
+    if (Platform.OS === 'ios') {
+      if (!isIosDeviceCompatible) {
+        return;
+      }
+      IoReactNativeCiePid.setAuthenticationUrl(url);
+      return;
+    }
+    IoReactNativeCiePid.setAuthenticationUrl(url);
+  };
+
+  const start = (config?: any) => {
+    if (Platform.OS === 'ios') {
+      if (!isIosDeviceCompatible) {
+        return Promise.reject('not compatible');
+      }
+      if (config !== undefined) {
+        Object.entries(config).forEach((kv) =>
+          IoReactNativeCiePid.setAlertMessage(kv[0], kv[1])
+        );
+      }
+    }
+    return new Promise<void>((resolve, reject) => {
+      IoReactNativeCiePid.start((err: any) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
+  };
+
+  const startListeningNFC = () => {
+    if (Platform.OS === 'ios') {
+      if (isIosDeviceCompatible) {
+        return Promise.resolve();
+      }
+      return Promise.reject('not implemented');
+    }
+    return new Promise<void>((resolve, reject) => {
+      IoReactNativeCiePid.startListeningNFC((err: any) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
+  };
+
+  const stopListeningNFC = () => {
+    if (Platform.OS === 'ios') {
+      // do nothing
+      return Promise.resolve();
+    }
+    return new Promise<void>((resolve, reject) => {
+      IoReactNativeCiePid.stopListeningNFC((err: any) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
+  };
+
+  const isCIEAuthenticationSupported = async () => {
+    try {
+      const nfcFeature = await hasNFCFeature();
+      const apiLevelSupport = await hasApiLevelSupport();
+      return Promise.resolve(nfcFeature && apiLevelSupport);
+    } catch {
+      return Promise.resolve(false);
+    }
+  };
+
+  /**
+   * Return true if the nfc is enabled, on the device in Settings screen
+   * is possible enable or disable it.
+   */
+  const isNFCEnabled = () => {
+    return new Promise((resolve) => {
+      IoReactNativeCiePid.isNFCEnabled((result: any) => {
+        resolve(result);
+      });
+    });
+  };
+
+  /**
+    return a Promise will be resolved with true if the current OS supports the authentication.
+    This method is due because with API level < 23 a security exception is raised
+    read more here - https://github.com/teamdigitale/io-cie-android-sdk/issues/10
+   */
+  const hasApiLevelSupport = () => {
+    if (Platform.OS === 'ios') {
+      return Promise.resolve(isIosDeviceCompatible);
+    }
+    return new Promise((resolve) => {
+      IoReactNativeCiePid.hasApiLevelSupport((result: any) => {
+        resolve(result);
+      });
+    });
+  };
+
+  /**
+   * Check if the hardware module nfc is installed (only for Android devices)
+   */
+  const hasNFCFeature = () => {
+    return new Promise((resolve) => {
+      IoReactNativeCiePid.hasNFCFeature((result: any) => {
+        resolve(result);
+      });
+    });
+  };
+
+  /**
+   * It opens OS Settings on NFC section
+   *
+   */
+  const openNFCSettings = () => {
+    if (Platform.OS === 'ios') {
+      return Promise.reject('not implemented');
+    }
+    return new Promise<void>((resolve, reject) => {
+      IoReactNativeCiePid.openNFCSettings((err: any) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
+  };
+
+  const launchCieID = () => {
+    if (Platform.OS === 'ios') {
+      return Promise.reject('not implemented');
+    }
+    return new Promise<void>((resolve, reject) => {
+      IoReactNativeCiePid.launchCieID((err: any) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
+  };
+
+  return {
+    onEvent,
+    onError,
+    onSuccess,
+    removeAllListeners,
+    setPin,
+    setAlertMessage,
+    setAuthenticationUrl,
+    start,
+    startListeningNFC,
+    stopListeningNFC,
+    isCIEAuthenticationSupported,
+    isNFCEnabled,
+    hasApiLevelSupport,
+    hasNFCFeature,
+    openNFCSettings,
+    launchCieID,
+  };
+};
+
+export default CieManager();


### PR DESCRIPTION
### Description

This PR adds the native bridge with event handler to read CIE data. The native bridge has the same interface of io-cie-sdk. This should make integration easier.

### How to test
- yarn
- yarn example android

Tap on **Start CIE Authentication** insert pin and tap on continue. Hold your cie card near NFC sensor of your device until the process end. If onSuccess you should see the result with authorization url and cieData with your firstname, lastname, fiscalCode and birthdate