### PR TITLE
[SIW-732] Downgrade nimbus-jose-jwt version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -107,7 +107,7 @@ ext {
   okhttp_version = '4.10.0'
   retrofit_version = '2.9.0'
   security_version = '1.1.0-alpha06'
-  jose_jwt_version = '9.23'
+  jose_jwt_version = '8.0'
   oauth2_version = '10.9.1'
 }
 


### PR DESCRIPTION
## Short description
This PR proposes a downgrade to the `nimbus-jose-jwt` library dependency of this repository.
The target version is now set to `8.0` which brings compatibility with the version used in [io-react-native-jwt](https://github.com/pagopa/io-react-native-jwt) according to the [build.gradle](https://github.com/pagopa/io-react-native-jwt/blob/f75e460c368ed05bf28a1ff7b1ae297b7dc959e2/android/build.gradle#L86). This library is a dependency of [io-react-native-wallet](https://github.com/pagopa/io-react-native-wallet).

## How to test
Test the example app, everything should work as expected.